### PR TITLE
Update TrackCrafts for V Rising 1.1

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,6 +2,6 @@
     "cSpell.words": [
         "Reloadable",
         "Unhollower",
-        "Wetstone"
+        "Bloodstone"
     ]
 }

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Note: Currently not auto updating
 ⚙️ Hot reloading with [Bloodstone API](https://github.com/decaprime/Bloodstone/releases)
 
 ### Installation
-- Install [BepInExPack V Rising](https://github.com/decaprime/VRising-Modding/releases/tag/1.668.2)
+- Install [BepInExPack V Rising](https://github.com/decaprime/VRising-Modding/releases/tag/1.733.2)
 - Install [Bloodstone API](https://github.com/decaprime/Bloodstone/releases)
 - Extract ``TrackCrafts.dll`` folder into _(VRising folder)/BepInEx/plugins_ or _(VRising folder)/BepInEx/BloodstonePlugins_
 
@@ -18,6 +18,11 @@ This is my first plugin, as well as my first time touching any game engine. If y
 - Auto update cost details as you add items to your inventory
 
 ### Changelog
+
+`1.1.0`
+- Updated for V Rising 1.1
+- Requires Bloodstone 0.2.3
+- Updated dependencies and BepInEx version
 
 `0.0.6`
 - Gloomrot Update

--- a/TrackCrafts.csproj
+++ b/TrackCrafts.csproj
@@ -4,7 +4,7 @@
         <TargetFramework>net6.0</TargetFramework>
         <AssemblyName>TrackCrafts</AssemblyName>
         <Description>Middle click on a recipe to track it. F1 to clear all. F2 to show/hide all</Description>
-        <Version>0.0.6</Version>
+        <Version>1.1.0</Version>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
         <LangVersion>latest</LangVersion>
     </PropertyGroup>
@@ -12,8 +12,8 @@
     <ItemGroup>
         <PackageReference Include="BepInEx.Unity.IL2CPP" Version="6.0.0-be*" IncludeAssets="compile" />
         <PackageReference Include="BepInEx.Core" Version="6.0.0-be*" IncludeAssets="compile" />
-        <PackageReference Include="VRising.Bloodstone" Version="0.1.1" />
-        <PackageReference Include="VRising.Unhollowed.Client" Version="0.6.5.57575003" />
+        <PackageReference Include="VRising.Bloodstone" Version="0.2.3" />
+        <PackageReference Include="VRising.Unhollowed.Client" Version="1.1.8.9179701" />
     </ItemGroup>
 
 </Project>

--- a/manifest.json
+++ b/manifest.json
@@ -1,10 +1,10 @@
 {
   "name": "TrackCrafts",
-  "version_number": "0.0.5",
+  "version_number": "1.1.0",
   "website_url": "https://github.com/armanckeser/TrackCrafts",
   "description": "Adds the ability to pin multiple crafting recipes",
   "dependencies": [
-    "BepInEx-BepInExPack_V_Rising-1.0.0",
-    "molenzwiebel-Wetstone-1.1.0"
+    "BepInEx-BepInExPack_V_Rising-1.1.0",
+    "gg.deca-Bloodstone-0.2.3"
   ]
 }

--- a/src/Plugin.cs
+++ b/src/Plugin.cs
@@ -15,7 +15,7 @@ public class Plugin : BasePlugin
 {
     private const string PluginGuid = "armanckeser.vrising.trackcrafts";
     private const string PluginName = "TrackCrafts";
-    private const string PluginVersion = "0.0.6";
+    private const string PluginVersion = "1.1.0";
      public static ManualLogSource Logger { get; private set; }
     public static ConfigEntry<int> TrackQuantity { get; private set; }
     public static ConfigEntry<float> TrackerItemScale { get; private set; }


### PR DESCRIPTION
## Summary
- bump plugin version to `1.1.0`
- update Bloodstone and Unhollowed package versions
- update manifest dependencies for Bloodstone and BepInEx
- refresh README with new install instructions and changelog
- cleanup VS Code settings

## Testing
- `dotnet build -c Release` *(fails: Unable to load the service index for https://nuget.bepinex.dev/v3/index.json)*

------
https://chatgpt.com/codex/tasks/task_e_683f705740d4832dba0417a1aa737964